### PR TITLE
warning fixups, cleanup when unloading

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/httpServer.js
+++ b/httpServer.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import {DeviceEventEmitter, NativeModules} from 'react-native';
+import {NativeEventEmitter, NativeModules} from 'react-native';
 const Server = NativeModules.HttpServer;
+const ServerEventEmitter = new NativeEventEmitter(Server);
 
 module.exports = {
     start: function (port, serviceName, callback) {
@@ -10,12 +11,12 @@ module.exports = {
         }
 
         Server.start(port, serviceName);
-        DeviceEventEmitter.addListener('httpServerResponseReceived', callback);
+        ServerEventEmitter.addListener('httpServerResponseReceived', callback);
     },
 
     stop: () => {
         Server.stop();
-        DeviceEventEmitter.removeAllListeners('httpServerResponseReceived');
+        ServerEventEmitter.removeAllListeners('httpServerResponseReceived');
     },
 
     respond: (requestId, code, type, body) => Server.respond(requestId, code, type, body)

--- a/ios/RCTHttpServer.m
+++ b/ios/RCTHttpServer.m
@@ -24,6 +24,11 @@ static RCTBridge *bridge;
 
 RCT_EXPORT_MODULE();
 
+- (void)invalidate {
+    [self stop];
+    [super invalidate];
+}
+
 - (NSArray<NSString *> *)supportedEvents {
     return @[
         @"httpServerResponseReceived"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-http-bridge-refurbished",
-    "version": "0.0.1",
+    "version": "0.0.0-development",
     "description": "A simple HTTP debug server for React Native apps",
     "main": "index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,41 +1,42 @@
 {
-  "name": "react-native-http-bridge-refurbished",
-  "version": "0.0.0-development",
-  "description": "A simple HTTP debug server for React Native apps",
-  "main": "index.js",
-  "types": "index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Alwinator/react-native-http-bridge-refurbished.git"
-  },
-  "keywords": [
-    "react-component",
-    "react-native",
-    "nanohttpd",
-    "gcdhttpserver",
-    "http",
-    "server",
-    "bridge"
-  ],
-  "author": "Alwin Schuster",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Alwinator/react-native-http-bridge-refurbished/issues"
-  },
-  "homepage": "https://github.com/Alwinator/react-native-http-bridge-refurbished#readme",
-  "scripts": {
-    "semantic-release": "semantic-release"
-  },
-  "dependencies": {
-    "react-native": "^0.71.3"
-  },
-  "devDependencies": {
-    "semantic-release": "^21.0.1"
-  },
-  "release": {
-    "branches": [
-      "main",
-      "next"
-    ]
-  }
+    "name": "react-native-http-bridge-refurbished",
+    "version": "0.0.1",
+    "description": "A simple HTTP debug server for React Native apps",
+    "main": "index.js",
+    "types": "index.d.ts",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Alwinator/react-native-http-bridge-refurbished.git",
+        "directory": "packages/react-native-http-bridge-refurbished"
+    },
+    "keywords": [
+        "react-component",
+        "react-native",
+        "nanohttpd",
+        "gcdhttpserver",
+        "http",
+        "server",
+        "bridge"
+    ],
+    "author": "Alwin Schuster",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/Alwinator/react-native-http-bridge-refurbished/issues"
+    },
+    "homepage": "https://github.com/Alwinator/react-native-http-bridge-refurbished#readme",
+    "scripts": {
+        "semantic-release": "semantic-release"
+    },
+    "dependencies": {
+        "react-native": "^0.71.3"
+    },
+    "devDependencies": {
+        "semantic-release": "^21.0.1"
+    },
+    "release": {
+        "branches": [
+            "main",
+            "next"
+        ]
+    }
 }


### PR DESCRIPTION
This PR does the following:

1.  The original implementation was using React Native's deprecated mechanism for sending events to Javascript from an iOS Native Module.   I updated the code to base the module off of `RCTEventEmitter` and use the `sendEventWithName` method.

2. I noticed that when reloading my app in the simulator (Cmd+R) the GCDWebServer would be held open and continue holding the port open.   This prevented the reloaded app from starting the server with that same port.    I added code to stop the server when the native module is invalidated/unloaded.